### PR TITLE
PROD-1675: Bumping Hopper Runner version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM deliveroo/hopper-runner:1.5.2 as hopper-runner
+FROM deliveroo/hopper-runner:1.8.0 as hopper-runner
 FROM node:10
 
 COPY --from=hopper-runner /hopper-runner /usr/bin/hopper-runner


### PR DESCRIPTION
Older versions of Hopper Runner will have difficulty with retrieving secrets from S3 because of a bug with environment variables starting with `AWS_` (which this app has).